### PR TITLE
Support starting in any state by env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ For use with Sparkplug B specifcation. Defines the edge_node_id. Default value i
 
 The tick speed of the simulation in milliseconds. This is optional. Default is 1000.
 
+### PACKML_INITIAL_START_STATE
+
+Optional environment variable can be set to any valid state to start the simulator in an alternate state. When unset defaults to 'clearing' state. For example set `PACKML_INITIAL_START_STATE=starting` to have the simulated machine auto-start.
+
 ## Enterprise Simulation
 
 Use docker-compose to simulate multiple independent lines at once. E.g.

--- a/src/packml-model.js
+++ b/src/packml-model.js
@@ -4,7 +4,7 @@
 const JavascripStateMachine = require('javascript-state-machine')
 
 // Define initial start state here
-const INITIAL_START_STATE = 'clearing'
+const INITIAL_START_STATE = process.env.PACKML_INITIAL_START_STATE || 'clearing'
 
 const WAITING_STATES = ['stopped', 'idle', 'held', 'suspend', 'complete', 'aborted', 'execute', 'undefined']
 


### PR DESCRIPTION
Small change to allow an environmental variable to set the starting state. Without the variable, the behavior of the simulator is unchanged.

Also added relevant documentation to the readme.