### PR TITLE
Standardize Line name to match other defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The ISA-95 Model area name of this line. AREA used as the second topic in the MQ
 
 ### LINE
 
-The ISA-95 model line name of this line. LINE used as the third topic in the MQTT structure. If this is unset, hostname will be used.
+The ISA-95 model line name of this line. LINE used as the third topic in the MQTT structure. If this is unset, _Line_ will be used.
 
 ### MQTT_URL
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ logger.info('Initializing')
 global.config = {
   site: process.env.SITE || 'Site',
   area: process.env.AREA || 'Area',
-  line: process.env.LINE || os.hostname(),
+  line: process.env.LINE || 'Line',
   startOnLoad: process.env.START || false,
   MQTT_URL: process.env.MQTT_URL || 'mqtt://broker.hivemq.com',
   MQTT_PORT: process.env.MQTT_PORT || null,


### PR DESCRIPTION
It seems more logical to me to have the default line name be `Line`:
- It matches the conventions for site and area
- It keeps the casing convention of the topic structure, which a hostname might not have
- In examples, the rendered hostname could confuse readers and users, where `Site/Area/Line` is more immediately obvious.